### PR TITLE
symbol-external-p: change error to warn

### DIFF
--- a/src/misc.lisp
+++ b/src/misc.lisp
@@ -23,7 +23,7 @@ the CADR of the list."
                                                    ((eq (car symbol) 'setf)
                                                     (cadr symbol))
                                                    (t
-                                                    (error "Unknown symbol type: ~s" symbol))))
+                                                    (warn "Unknown symbol type: ~s" symbol))))
                                 package))
       :external))
 


### PR DESCRIPTION
this allows me to see the common-lisp page. Otherwise, I'm blocked.

Best,