### PR TITLE
make docbrowser restartable and add option to restrict listening addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ can also be given with an optional `:port` argument.
 To access the docbrowser, point a web browser to
 http://localhost:8080/
 
+To restrict docbrowser to localhost requests, or changing the used port to 5432, you can start it with following command from the REPL:
+
+```lisp
+(docbrowser:start-docserver :port 5432 :address "127.0.0.1")
+```
+
+
 The main page presents a list of all the available packages. You can
 click on one to see its functions and variables, with their
 docstrings. You can also go to a function's source.

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -70,18 +70,19 @@ written to."
 (defvar *global-acceptor* nil
   "The acceptor for the currently running server.")
 
-(defun start-docserver (&optional (port 8080))
-  "Start the documentation server with a HTTP listener on port PORT."
+(defun start-docserver (&key (port 8080) (address nil))
+  "Start the documentation server with a HTTP listener on port PORT.
+parameter ADDRESS restricts server listening to IP address"
   (when *global-acceptor*
     (error "Server is already running"))
-  (let ((a (make-instance 'docbrowser-acceptor :port port)))
+  (let ((a (make-instance 'docbrowser-acceptor :port port :address address)))
     (hunchentoot:start a)
     (setq *global-acceptor* a))
   (setq hunchentoot:*show-lisp-errors-p* t)
   (setq hunchentoot:*log-lisp-warnings-p* t)
   (setq hunchentoot:*log-lisp-backtraces-p* t)
   (setf (hunchentoot:acceptor-access-log-destination *global-acceptor*) (make-broadcast-stream))
-  (format t "Docserver started on port ~a" port)
+  (format t "Docserver started on port ~a; listening to IP ~a" port (or address 'any))
   (values))
 
 (defun stop-docserver ()
@@ -89,4 +90,4 @@ written to."
   (unless *global-acceptor*
     (error "Server is not running"))
   (hunchentoot:stop *global-acceptor*)
-  (setf *global-acceptor* nil)
+  (setf *global-acceptor* nil))

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -88,4 +88,5 @@ written to."
   "Stop the documentation server."
   (unless *global-acceptor*
     (error "Server is not running"))
-  (hunchentoot:stop *global-acceptor*))
+  (hunchentoot:stop *global-acceptor*)
+  (setf *global-acceptor* nil)


### PR DESCRIPTION
docbrowser could not be started again, after stop it, due to not resetting `*global-acceptor*`. this pull request changes that.

docbrowser server always answered to any IP address in network, this pull request gives the user an option to listen only to certain IP addresses.

`start-server` uses now keyword parameters instead of optional parameters.

Example to make docbrowser only listen to localhost requests:

      (docbrowser:start-server :port 8080 :address "127.0.0.1")